### PR TITLE
Mindestruhegehalt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": "^7.4|^8.1",
         "dgame/php-ensurance": "^2.3",
-        "demvsystems/werte": "^v2.0"
+        "demvsystems/werte": "^v2.0",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0|^9.5"

--- a/src/Pension/BeamtenPensionRechner.php
+++ b/src/Pension/BeamtenPensionRechner.php
@@ -76,7 +76,7 @@ final class BeamtenPensionRechner
         $dienstjahre = $this->pensionseintritt - $this->dienstzeitbeginn;
 
         if ($dienstjahre < self::MIN_DIENSTJAHRE) {
-            return new Pensionsberechnung(0, false);
+            return new Pensionsberechnung(0, $this->pensionseintritt, false);
         }
 
         $pensionssatz = self::PENSIONSSATZ_FAKTOR * $dienstjahre / 100;
@@ -88,9 +88,9 @@ final class BeamtenPensionRechner
         $mindestruhegehalt = self::getMindestruhegehalt();
 
         if ($pensionsbetrag < $mindestruhegehalt) {
-            return new Pensionsberechnung($mindestruhegehalt, true);
+            return new Pensionsberechnung($mindestruhegehalt, $this->pensionseintritt, true);
         }
 
-        return new Pensionsberechnung($pensionsbetrag, false);
+        return new Pensionsberechnung($pensionsbetrag, $this->pensionseintritt, false);
     }
 }

--- a/src/Pension/BeamtenPensionRechner.php
+++ b/src/Pension/BeamtenPensionRechner.php
@@ -4,24 +4,8 @@ namespace Finanzrechner\Pension;
 
 use Exception;
 
+use Throwable;
 use function Dgame\Ensurance\ensure;
-
-/**
- * Class BeamtenPensionRechner
- * @package Finanzrechner\Pension
- */
-
-class Pensionsberechnung
-{
-    public float $pensionsbetrag;
-    public bool $isMindestruhegehalt;
-
-    public function __construct(float $pensionsbetrag, bool $isMindestruhegehalt)
-    {
-        $this->pensionsbetrag      = $pensionsbetrag;
-        $this->isMindestruhegehalt = $isMindestruhegehalt;
-    }
-}
 
 final class BeamtenPensionRechner
 {
@@ -38,20 +22,19 @@ final class BeamtenPensionRechner
     private const MIN_PENSIONSSATZ_MINDESTRUHEGEHALT    = 0.65;
 
     /**
-     * Enthält das Jahr in dem der Kunde seinen Beamtendienst antritt
-     * @var int|null
+     * Enthält das Jahr, in dem der Kunde seinen Beamtendienst antritt
      */
-    private $dienstzeitbeginn;
+    private ?int $dienstzeitbeginn = null;
 
     /**
      * Enthält das Jahr, in dem der Kunde seinen Beamtendienst beendet und in die
      * Pension eintritt
-     * @var int
      */
-    private $pensionseintritt;
+    private ?int $pensionseintritt = null;
 
     /**
      * @param int $dienstzeitbeginn
+     * @throws Throwable
      */
     public function setDienstzeitbeginn(int $dienstzeitbeginn): void
     {
@@ -61,6 +44,7 @@ final class BeamtenPensionRechner
 
     /**
      * @param int $pensionseintritt
+     * @throws Throwable
      */
     public function setPensionseintritt(int $pensionseintritt): void
     {
@@ -68,7 +52,7 @@ final class BeamtenPensionRechner
         $this->pensionseintritt = $pensionseintritt;
     }
 
-    public static function mindestruhegehalt(): float
+    public static function getMindestruhegehalt(): float
     {
         return self::NETTO_ENDSTUFE_A4 * self::MIN_PENSIONSSATZ_MINDESTRUHEGEHALT;
     }
@@ -78,7 +62,8 @@ final class BeamtenPensionRechner
      *
      * @param float $dienstbezuege
      *
-     * @return float
+     * @return Pensionsberechnung
+     * @throws Throwable
      */
     public function calc(float $dienstbezuege): Pensionsberechnung
     {
@@ -100,7 +85,7 @@ final class BeamtenPensionRechner
 
         $pensionsbetrag = $dienstbezuege * $effectivePensionssatz;
 
-        $mindestruhegehalt = self::mindestruhegehalt();
+        $mindestruhegehalt = self::getMindestruhegehalt();
 
         if ($pensionsbetrag < $mindestruhegehalt) {
             return new Pensionsberechnung($mindestruhegehalt, true);

--- a/src/Pension/BeamtenPensionRechner.php
+++ b/src/Pension/BeamtenPensionRechner.php
@@ -2,9 +2,9 @@
 
 namespace Finanzrechner\Pension;
 
-use function Dgame\Ensurance\ensure;
-
 use Exception;
+
+use function Dgame\Ensurance\ensure;
 
 /**
  * Class BeamtenPensionRechner
@@ -18,7 +18,7 @@ class Pensionsberechnung
 
     public function __construct(float $pensionsbetrag, bool $isMindestruhegehalt)
     {
-        $this->pensionsbetrag = $pensionsbetrag;
+        $this->pensionsbetrag      = $pensionsbetrag;
         $this->isMindestruhegehalt = $isMindestruhegehalt;
     }
 }

--- a/src/Pension/Pensionsberechnung.php
+++ b/src/Pension/Pensionsberechnung.php
@@ -6,7 +6,7 @@ namespace Finanzrechner\Pension;
  * Class BeamtenPensionRechner
  * @package Finanzrechner\Pension
  */
-class Pensionsberechnung
+class Pensionsberechnung implements \JsonSerializable
 {
     private float $pensionsbetrag;
 
@@ -26,5 +26,13 @@ class Pensionsberechnung
     public function isMindestruhegehalt(): bool
     {
         return $this->isMindestruhegehalt;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'pensionsbetrag' => $this->pensionsbetrag,
+            'isMindestruhegehalt' => $this->isMindestruhegehalt
+        ];
     }
 }

--- a/src/Pension/Pensionsberechnung.php
+++ b/src/Pension/Pensionsberechnung.php
@@ -24,7 +24,7 @@ class Pensionsberechnung
 
     public function __construct(float $pensionsbetrag, bool $isMindestruhegehalt)
     {
-        $this->pensionsbetrag = $pensionsbetrag;
+        $this->pensionsbetrag      = $pensionsbetrag;
         $this->isMindestruhegehalt = $isMindestruhegehalt;
     }
 }

--- a/src/Pension/Pensionsberechnung.php
+++ b/src/Pension/Pensionsberechnung.php
@@ -17,7 +17,7 @@ class Pensionsberechnung implements \JsonSerializable
     public function __construct(float $pensionsbetrag, float $pensionseintritt, bool $isMindestruhegehalt)
     {
         $this->pensionsbetrag      = $pensionsbetrag;
-        $this->pensionseintritt    = $pensionseintritt;
+        $this->pensionseintritt   = $pensionseintritt;
         $this->isMindestruhegehalt = $isMindestruhegehalt;
     }
 
@@ -40,7 +40,7 @@ class Pensionsberechnung implements \JsonSerializable
     {
         return [
             'pensionsbetrag'      => $this->pensionsbetrag,
-            '$pensionseintritt'   => $this->pensionseintritt,
+            'pensionseintritt'   => $this->pensionseintritt,
             'isMindestruhegehalt' => $this->isMindestruhegehalt
         ];
     }

--- a/src/Pension/Pensionsberechnung.php
+++ b/src/Pension/Pensionsberechnung.php
@@ -17,7 +17,7 @@ class Pensionsberechnung implements \JsonSerializable
     public function __construct(float $pensionsbetrag, float $pensionseintritt, bool $isMindestruhegehalt)
     {
         $this->pensionsbetrag      = $pensionsbetrag;
-        $this->pensionseintritt   = $pensionseintritt;
+        $this->pensionseintritt    = $pensionseintritt;
         $this->isMindestruhegehalt = $isMindestruhegehalt;
     }
 
@@ -40,7 +40,7 @@ class Pensionsberechnung implements \JsonSerializable
     {
         return [
             'pensionsbetrag'      => $this->pensionsbetrag,
-            'pensionseintritt'   => $this->pensionseintritt,
+            'pensionseintritt'    => $this->pensionseintritt,
             'isMindestruhegehalt' => $this->isMindestruhegehalt
         ];
     }

--- a/src/Pension/Pensionsberechnung.php
+++ b/src/Pension/Pensionsberechnung.php
@@ -10,17 +10,25 @@ class Pensionsberechnung implements \JsonSerializable
 {
     private float $pensionsbetrag;
 
+    private float $pensionseintritt;
+
     private bool $isMindestruhegehalt;
 
-    public function __construct(float $pensionsbetrag, bool $isMindestruhegehalt)
+    public function __construct(float $pensionsbetrag, float $pensionseintritt, bool $isMindestruhegehalt)
     {
         $this->pensionsbetrag      = $pensionsbetrag;
+        $this->pensionseintritt   = $pensionseintritt;
         $this->isMindestruhegehalt = $isMindestruhegehalt;
     }
 
     public function getPensionsbetrag(): float
     {
         return $this->pensionsbetrag;
+    }
+
+    public function getPensionseintritt(): float
+    {
+        return $this->pensionseintritt;
     }
 
     public function isMindestruhegehalt(): bool
@@ -32,6 +40,7 @@ class Pensionsberechnung implements \JsonSerializable
     {
         return [
             'pensionsbetrag'      => $this->pensionsbetrag,
+            '$pensionseintritt'   => $this->pensionseintritt,
             'isMindestruhegehalt' => $this->isMindestruhegehalt
         ];
     }

--- a/src/Pension/Pensionsberechnung.php
+++ b/src/Pension/Pensionsberechnung.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Finanzrechner\Pension;
+
+/**
+ * Class BeamtenPensionRechner
+ * @package Finanzrechner\Pension
+ */
+class Pensionsberechnung
+{
+    private float $pensionsbetrag;
+
+    public function getPensionsbetrag(): float
+    {
+        return $this->pensionsbetrag;
+    }
+
+    public function isMindestruhegehalt(): bool
+    {
+        return $this->isMindestruhegehalt;
+    }
+
+    private bool $isMindestruhegehalt;
+
+    public function __construct(float $pensionsbetrag, bool $isMindestruhegehalt)
+    {
+        $this->pensionsbetrag = $pensionsbetrag;
+        $this->isMindestruhegehalt = $isMindestruhegehalt;
+    }
+}

--- a/src/Pension/Pensionsberechnung.php
+++ b/src/Pension/Pensionsberechnung.php
@@ -17,7 +17,7 @@ class Pensionsberechnung implements \JsonSerializable
     public function __construct(float $pensionsbetrag, float $pensionseintritt, bool $isMindestruhegehalt)
     {
         $this->pensionsbetrag      = $pensionsbetrag;
-        $this->pensionseintritt   = $pensionseintritt;
+        $this->pensionseintritt    = $pensionseintritt;
         $this->isMindestruhegehalt = $isMindestruhegehalt;
     }
 

--- a/src/Pension/Pensionsberechnung.php
+++ b/src/Pension/Pensionsberechnung.php
@@ -10,6 +10,14 @@ class Pensionsberechnung
 {
     private float $pensionsbetrag;
 
+    private bool $isMindestruhegehalt;
+
+    public function __construct(float $pensionsbetrag, bool $isMindestruhegehalt)
+    {
+        $this->pensionsbetrag      = $pensionsbetrag;
+        $this->isMindestruhegehalt = $isMindestruhegehalt;
+    }
+
     public function getPensionsbetrag(): float
     {
         return $this->pensionsbetrag;
@@ -18,13 +26,5 @@ class Pensionsberechnung
     public function isMindestruhegehalt(): bool
     {
         return $this->isMindestruhegehalt;
-    }
-
-    private bool $isMindestruhegehalt;
-
-    public function __construct(float $pensionsbetrag, bool $isMindestruhegehalt)
-    {
-        $this->pensionsbetrag      = $pensionsbetrag;
-        $this->isMindestruhegehalt = $isMindestruhegehalt;
     }
 }

--- a/src/Pension/Pensionsberechnung.php
+++ b/src/Pension/Pensionsberechnung.php
@@ -31,7 +31,7 @@ class Pensionsberechnung implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return [
-            'pensionsbetrag' => $this->pensionsbetrag,
+            'pensionsbetrag'      => $this->pensionsbetrag,
             'isMindestruhegehalt' => $this->isMindestruhegehalt
         ];
     }

--- a/src/Rente/GesetzlicheRenteRechner.php
+++ b/src/Rente/GesetzlicheRenteRechner.php
@@ -2,8 +2,8 @@
 
 namespace Finanzrechner\Rente;
 
-use function Dgame\Ensurance\ensure;
 use InvalidArgumentException;
+use function Dgame\Ensurance\ensure;
 
 /**
  * Class GesetzlicheRenteRechner

--- a/tests/Kapitalstock/KapitalstockRechnerTest.php
+++ b/tests/Kapitalstock/KapitalstockRechnerTest.php
@@ -42,7 +42,7 @@ final class KapitalstockRechnerTest extends TestCase
     {
         foreach ($this->testcases as $testcase) {
             $this->assertEquals($testcase['kapitalstock'],
-                                (new KapitalstockRechner($testcase['zinssatz']))->calc($testcase['entnahme'], $testcase['laufzeit']));
+                (new KapitalstockRechner($testcase['zinssatz']))->calc($testcase['entnahme'], $testcase['laufzeit']));
         }
     }
 }

--- a/tests/Pension/BeamtenPensionRechnerTest.php
+++ b/tests/Pension/BeamtenPensionRechnerTest.php
@@ -142,4 +142,17 @@ final class BeamtenPensionRechnerTest extends TestCase
         $this->assertEquals($minRuhegehalt, $result->getPensionsbetrag());
         $this->assertTrue($result->isMindestruhegehalt());
     }
+
+    /**
+     * @throws Throwable
+     */
+    public function testPensionseintritt()
+    {
+        $this->rechner->setDienstzeitbeginn(2000);
+        $this->rechner->setPensionseintritt(2035);
+
+        $result = $this->rechner->calc(5000);
+
+        $this->assertEquals(2035, $result->getPensionseintritt());
+    }
 }

--- a/tests/Pension/BeamtenPensionRechnerTest.php
+++ b/tests/Pension/BeamtenPensionRechnerTest.php
@@ -6,6 +6,7 @@ use Dgame\Ensurance\Exception\EnsuranceException;
 use Exception;
 use Finanzrechner\Pension\BeamtenPensionRechner;
 use PHPUnit\Framework\TestCase;
+use Throwable;
 
 /**
  * Class BeamtenPensionRechner
@@ -13,8 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class BeamtenPensionRechnerTest extends TestCase
 {
-    /** @var BeamtenPensionRechner $rechner */
-    private $rechner;
+    private BeamtenPensionRechner $rechner;
 
     protected function setUp(): void
     {
@@ -23,6 +23,9 @@ final class BeamtenPensionRechnerTest extends TestCase
         $this->rechner = new BeamtenPensionRechner();
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testCalcNoPension()
     {
         // Bei weniger als fünf Jahren Dienstzeit wird keine Pension gezahlt
@@ -31,14 +34,17 @@ final class BeamtenPensionRechnerTest extends TestCase
 
         $result = $this->rechner->calc(1000);
 
-        $this->assertEquals(0, $result->pensionsbetrag);
-        $this->assertFalse($result->isMindestruhegehalt);
+        $this->assertEquals(0, $result->getPensionsbetrag());
+        $this->assertFalse($result->isMindestruhegehalt());
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testCalcMinimumPension()
     {
         // Bei weniger als 20 Jahren Dienstzeit errechnet sich ein Pensionssatz von
-        // weniger als 35% -> Minimum der Pension ist immer 35% von den Dienstbezügen
+        // weniger als 35 % → Minimum der Pension ist immer 35 % von den Dienstbezügen
         $this->rechner->setDienstzeitbeginn(2000);
         $this->rechner->setPensionseintritt(2010);
 
@@ -46,14 +52,17 @@ final class BeamtenPensionRechnerTest extends TestCase
         // hoch genug ist
         $result = $this->rechner->calc(6000);
 
-        $this->assertEquals(0.35 * 6000, $result->pensionsbetrag);
-        $this->assertFalse($result->isMindestruhegehalt);
+        $this->assertEquals(0.35 * 6000, $result->getPensionsbetrag());
+        $this->assertFalse($result->isMindestruhegehalt());
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testCalcMaximumPension()
     {
         // Nach 40+ Jahren Dienstzeit errechnet sich ein Pensionssatz von größer als
-        // 71.75 % -> Maximum der Pension ist 71.75% von den Dienstbezügen
+        // 71,75 % → Maximum der Pension ist 71,75 % von den Dienstbezügen
         $this->rechner->setDienstzeitbeginn(2000);
         $this->rechner->setPensionseintritt(2041);
 
@@ -61,10 +70,13 @@ final class BeamtenPensionRechnerTest extends TestCase
         // hoch genug ist
         $result = $this->rechner->calc(4000);
 
-        $this->assertEquals(0.7175 * 4000, $result->pensionsbetrag);
-        $this->assertFalse($result->isMindestruhegehalt);
+        $this->assertEquals(0.7175 * 4000, $result->getPensionsbetrag());
+        $this->assertFalse($result->isMindestruhegehalt());
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testCalcPension()
     {
         $this->rechner->setDienstzeitbeginn(2000);
@@ -74,34 +86,49 @@ final class BeamtenPensionRechnerTest extends TestCase
         $result  = $this->rechner->calc(4000);
         $pension = 1.79375 * 25 / 100 * 4000;
 
-        $this->assertEquals($pension, $result->pensionsbetrag);
-        $this->assertFalse($result->isMindestruhegehalt);
+        $this->assertEquals($pension, $result->getPensionsbetrag());
+        $this->assertFalse($result->isMindestruhegehalt());
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testThrowsIfDienstzeitOrPensionseintrittNotSet()
     {
         $this->expectException(Exception::class);
         $this->rechner->calc(1000);
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testThrowsIfDienstbezuegeIsNegative()
     {
         $this->expectException(EnsuranceException::class);
         $this->rechner->calc(-1000);
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testThrowsIfDienstzeitbeginnIsNegative()
     {
         $this->expectException(EnsuranceException::class);
         $this->rechner->setDienstzeitbeginn(-1);
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testThrowsIfPensionseintrittIsNegative()
     {
         $this->expectException(EnsuranceException::class);
         $this->rechner->setPensionseintritt(-1);
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testPensionIsMinRuhegehalt()
     {
         // ist das amtsabhängige Mindestruhegehalt kleiner als das amtsunabhängige Mindestruhegehalt sollte
@@ -110,9 +137,9 @@ final class BeamtenPensionRechnerTest extends TestCase
         $this->rechner->setPensionseintritt(2025);
 
         $result        = $this->rechner->calc(1000);
-        $minRuhegehalt = BeamtenPensionRechner::mindestruhegehalt();
+        $minRuhegehalt = BeamtenPensionRechner::getMindestruhegehalt();
 
-        $this->assertEquals($minRuhegehalt, $result->pensionsbetrag);
-        $this->assertTrue($result->isMindestruhegehalt);
+        $this->assertEquals($minRuhegehalt, $result->getPensionsbetrag());
+        $this->assertTrue($result->isMindestruhegehalt());
     }
 }

--- a/tests/Pension/BeamtenPensionRechnerTest.php
+++ b/tests/Pension/BeamtenPensionRechnerTest.php
@@ -71,7 +71,7 @@ final class BeamtenPensionRechnerTest extends TestCase
         $this->rechner->setPensionseintritt(2025);
 
         // Pensionssatz-Faktor * Anzahl Dienstjahre / 100 * Dienstbezüge
-        $result = $this->rechner->calc(4000);
+        $result  = $this->rechner->calc(4000);
         $pension = 1.79375 * 25 / 100 * 4000;
 
         $this->assertEquals($pension, $result->pensionsbetrag);
@@ -109,7 +109,7 @@ final class BeamtenPensionRechnerTest extends TestCase
         $this->rechner->setDienstzeitbeginn(2000);
         $this->rechner->setPensionseintritt(2025);
 
-        $result = $this->rechner->calc(1000);
+        $result        = $this->rechner->calc(1000);
         $minRuhegehalt = BeamtenPensionRechner::mindestruhegehalt();
 
         $this->assertEquals($minRuhegehalt, $result->pensionsbetrag);


### PR DESCRIPTION
Fügt das Mindestruhegehalt von Endstufe A4 x 0.65 dem Beamten-Pensions-Rechner hinzu

Notwendig für https://demvsystems.atlassian.net/jira/software/c/projects/LIEBE/boards/42?selectedIssue=FM-387